### PR TITLE
README: Fix links to NGLviewer website (documentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,9 @@ Embed widget
 
 API doc
 =======
-- [Latest version](http://arose.github.io/nglview/latest/api.html)
-- [All releases versions](http://arose.github.io/nglview/release/index.html)
-- [Development version](http://arose.github.io/nglview/dev/api.html)
+- [Latest version](http://nglviewer.github.io/nglview/latest/api.html)
+- [All releases versions](http://nglviewer.github.io/nglview/release/index.html)
+- [Development version](http://nglviewer.github.io/nglview/dev/api.html)
 
 Command line
 ============
@@ -365,8 +365,8 @@ FAQ
 Website
 =======
 
-- http://arose.github.io/nglview/latest
-- http://arose.github.io/nglview/dev
+- http://nglviewer.github.io/nglview/latest
+- http://nglviewer.github.io/nglview/dev
 
 Talks
 =====


### PR DESCRIPTION
## Description

I propose to update the README links to the NGLviewer documentation.
The links have changed probably because the GH repo ownership was changed to an organization as pointed out to me by @jaimergp.

Thanks for your work on the NGLviewer!

## ToDos
- [x] Update links from http://arose.github.io/nglview/... to http://nglviewer.github.io/nglview/...

## Questions

None.

## Status

- [x] Ready to go