### PR TITLE
Fix set_rotation method

### DIFF
--- a/nglview/component.py
+++ b/nglview/component.py
@@ -84,7 +84,7 @@ class ComponentViewer:
         ----------
         rot: List-like of float, length = 3
         """
-        self._call('setPosition', rot)
+        self._call('setRotation', rot)
 
     def set_scale(self, scale):
         """


### PR DESCRIPTION
There is a mistake in cut-and-paste in set_rotation method. The call should be to setRotation not setPosition