### PR TITLE
Update api doc links.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -180,11 +180,11 @@ view.update_cartoon(opacity=0.4, component=0)
 view.remove_cartoon(opacity=0.4, component=0)
 ```
 
-And many more, please check [NGL website](http://arose.github.io/ngl/api/index.html)
+And many more, please check [NGL website](http://nglviewer.org/ngl/api/index.html)
 
 Representations can also be changed by overwriting the `representations` property
 of the widget instance `view`. The available `type` and `params` are described
-in the NGL Viewer [documentation](http://arose.github.io/ngl/api/index.html).
+in the NGL Viewer [documentation](http://nglviewer.org/ngl/api/index.html).
 
 ```Python
 view.representations = [
@@ -323,9 +323,9 @@ movie.make()
 
 API doc
 =======
-- [Latest version](http://arose.github.io/nglview/latest/api.html)
-- [All releases versions](http://arose.github.io/nglview/release/index.html)
-- [Development version](http://arose.github.io/nglview/dev/api.html)
+- [Latest version](http://nglviewer.org/nglview/latest/api.html)
+- [All releases versions](http://nglviewer.org/nglview/release/index.html)
+- [Development version](http://nglviewer.org/nglview/dev/api.html)
 
 Command line
 ============
@@ -380,8 +380,8 @@ FAQ
 Website
 =======
 
-- http://arose.github.io/nglview/latest
-- http://arose.github.io/nglview/dev
+- http://nglviewer.org/nglview/latest
+- http://nglviewer.org/nglview/dev
 
 Talks
 =====

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -243,12 +243,12 @@ Representations
     view.remove_cartoon(opacity=0.4, component=0)
 
 And many more, please check `NGL
-website <http://arose.github.io/ngl/api/index.html>`__
+website <http://nglviewer.org/ngl/api/index.html>`__
 
 Representations can also be changed by overwriting the
 ``representations`` property of the widget instance ``view``. The
 available ``type`` and ``params`` are described in the NGL Viewer
-`documentation <http://arose.github.io/ngl/api/index.html>`__.
+`documentation <http://nglviewer.org/ngl/api/index.html>`__.
 
 .. code:: python
 
@@ -392,10 +392,10 @@ Notes: Unstable feature.
 API doc
 =======
 
--  `Latest version <http://arose.github.io/nglview/latest/api.html>`__
+-  `Latest version <http://nglviewer.org/nglview/latest/api.html>`__
 -  `All releases
-   versions <http://arose.github.io/nglview/release/index.html>`__
--  `Development version <http://arose.github.io/nglview/dev/api.html>`__
+   versions <http://nglviewer.org/nglview/release/index.html>`__
+-  `Development version <http://nglviewer.org/nglview/dev/api.html>`__
 
 Command line
 ============
@@ -450,8 +450,8 @@ FAQ
 Website
 =======
 
--  http://arose.github.io/nglview/latest
--  http://arose.github.io/nglview/dev
+-  http://nglviewer.org/nglview/latest
+-  http://nglviewer.org/nglview/dev
 
 Talks
 =====

--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -9,9 +9,9 @@
 -  2016
 
    -  `ngl-3dsig, Alexander
-      Rose <http://arose.github.io/talks/ngl-3dsig/>`__
+      Rose <http://nglviewer.org/talks/ngl-3dsig/>`__
    -  `ngl-web3d, Alexander
-      Rose <http://arose.github.io/talks/ngl-web3d>`__
+      Rose <http://nglviewer.org/talks/ngl-web3d>`__
 
 - Videos from users
     - `"The universe as balls and springs: molecular dynamics in Python" - Lily Wang (PyCon AU 2019)], <https://youtu.be/X5umNQDqfqQ>`__

--- a/talks.md
+++ b/talks.md
@@ -2,5 +2,5 @@
     - [AMBER developer meeting, Hai Nguyen](http://hainm.github.io/talks/amber_meeting_2017/)
     - [PyEMMA 2017, projX: Interative molecular projection visualization,  Guillermo Pérez-Hernández](https://www.youtube.com/watch?v=AT69NfUMV2U)
 - 2016
-    - [ngl-3dsig, Alexander Rose](http://arose.github.io/talks/ngl-3dsig/)
-    - [ngl-web3d, Alexander Rose](http://arose.github.io/talks/ngl-web3d)
+    - [ngl-3dsig, Alexander Rose](http://nglviewer.org/talks/ngl-3dsig/)
+    - [ngl-web3d, Alexander Rose](http://nglviewer.org/talks/ngl-web3d)


### PR DESCRIPTION
Update api doc links from https://arose.github.io to https://nglviewer.org

Note: I believe the talk links are broken since there is no equivalent uri on https://nglviewer.org

**Issues**
https://github.com/ng/viewer/ngl/issues/815
https://github.com/nglviewer/ngl/issues/934