### PR TITLE
Fixes #939 - Visualiser no longer be blank in Jupyter Lab on first load.

### DIFF
--- a/js/src/gui.js
+++ b/js/src/gui.js
@@ -262,6 +262,10 @@ class StageWidget{
           // FIXME
           var sw = sidebar.dom.getBoundingClientRect().width
           var ew = el.getBoundingClientRect().width
+          if (ew == sw) {
+              sw = 300 // could be set as percentage of ew?
+          }
+
           var w = ew - sw + 'px'
 
           stage.viewer.container.style.width = w 

--- a/js/src/gui.js
+++ b/js/src/gui.js
@@ -263,7 +263,7 @@ class StageWidget{
           var sw = sidebar.dom.getBoundingClientRect().width
           var ew = el.getBoundingClientRect().width
           if (ew == sw) {
-              sw = 300 // could be set as percentage of ew?
+              sw = ew / 4
           }
 
           var w = ew - sw + 'px'


### PR DESCRIPTION
Prior, selecting `gui_style = 'ngl'` in lab resulted in blank interface due to giving the canvas a `0px` width.

Unfortunately I can't get the build to behave - seems to be an issue with type checking - but it should work.