### PR TITLE
Handle exception if "path too long" on Windows

### DIFF
--- a/nglview/utils/py_utils.py
+++ b/nglview/utils/py_utils.py
@@ -252,7 +252,11 @@ class FileManager:
         if hasattr(self.src, 'read'):
             return False
         else:
-            return os.path.isfile(self.src)
+            # This can fail on Windows with "path too long"
+            try:
+                return os.path.isfile(self.src)
+            except ValueError:
+                return False
 
     @property
     def is_binary(self):


### PR DESCRIPTION
Testing whether the provided string is a filename or some file contents fails on Windows with `path too long`. This PR handles that exception to return False if it happens.

See error [here](https://github.com/volkamerlab/teachopencadd/pull/74/checks?check_run_id=2600210648#step:8:98).