### PR TITLE
bugfix: py_utils.get_name and widget.NGLwidget

### DIFF
--- a/nglview/tests/test_utils.py
+++ b/nglview/tests/test_utils.py
@@ -19,8 +19,8 @@ def assert_equal(x, y):
 
 def test_get_name():
     fn = nglview.datafiles.PDB
-    assert_equal(py_utils.get_name(object, dict(name='hello')), 'hello')
-    assert_equal(py_utils.get_name(nglview.FileStructure(fn), dict()),
+    assert_equal(py_utils.get_name(object, name='hello'), 'hello')
+    assert_equal(py_utils.get_name(nglview.FileStructure(fn)),
                  'nglview.adaptor.FileStructure')
 
 

--- a/nglview/utils/py_utils.py
+++ b/nglview/utils/py_utils.py
@@ -51,7 +51,7 @@ def decode_base64(data, shape, dtype='f4'):
     return np.frombuffer(decoded_str, dtype=dtype).reshape(shape)
 
 
-def get_name(obj, kwargs):
+def get_name(obj, **kwargs):
     name = kwargs.pop('name', str(obj))
     if name.startswith('<nglview.'):
         name = name.split()[0].strip('<')

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -233,12 +233,12 @@ class NGLWidget(DOMWidget):
         if parameters:
             self.parameters = parameters
         if isinstance(structure, Trajectory):
-            name = py_utils.get_name(structure, kwargs)
+            name = py_utils.get_name(structure, **kwargs)
             self.add_trajectory(structure, name=name, **kwargs)
         elif isinstance(structure, (list, tuple)):
             trajectories = structure
             for trajectory in trajectories:
-                name = py_utils.get_name(trajectory, kwargs)
+                name = py_utils.get_name(trajectory, **kwargs)
                 self.add_trajectory(trajectory, name=name, **kwargs)
         else:
             if structure is not None:
@@ -849,7 +849,7 @@ class NGLWidget(DOMWidget):
         cid = str(uuid.uuid4())
         self._ngl_component_ids.append(cid)
 
-        comp_name = py_utils.get_name(self.shape, {})
+        comp_name = py_utils.get_name(self.shape)
         self._ngl_component_names.append(comp_name)
 
         self._update_component_auto_completion()
@@ -1258,7 +1258,7 @@ class NGLWidget(DOMWidget):
             url = obj
             args = [{'type': blob_type, 'data': url, 'binary': False}]
 
-        name = py_utils.get_name(obj, kwargs2)
+        name = py_utils.get_name(obj, **kwargs2)
         self._ngl_component_names.append(name)
         self._remote_call("loadFile",
                           target='Stage',


### PR DESCRIPTION
Giving arbitrary names when adding component is now possible, before, these calls:

`iwd.add_component(nglview.FileStructure("test.pdb"),name="test")`
`comp = iwd.add_component(nglview.FileStructure("test.pdb"),{"name":"test"})`

resulted in nothing or error (see screenshot), because `kwargs` was being passed internally instead of `**kwargs`

@hainm, I hope it's okay I opened the PR directly, this one was driving me crazy since last week ;) 

![Screenshot_20210608_112955](https://user-images.githubusercontent.com/7518004/121160911-cac65f80-c84c-11eb-8344-61ffd07840fb.png)

