### PR TITLE
Pin ipywidget version to 7

### DIFF
--- a/.github/nglview-gha.yml
+++ b/.github/nglview-gha.yml
@@ -10,7 +10,7 @@ dependencies:
   - jupyter-packaging
   - qcelemental
   - traitlets
-  - ipywidgets
+  - ipywidgets==7.*
   - mock
   - coverage
   - nose

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ jupyter notebook --NotebookApp.iopub_data_rate_limit=10000000
 Development version
 -------------------
 
-Requirement: `ipywidgets >= 7.0`, `notebook >= 4.2`
+Requirement: `ipywidgets >= 7.0,<8`, `notebook >= 4.2`
 
 The development version can be installed directly from github:
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -7,13 +7,13 @@ requirements:
     - python
     - setuptools
     - jupyter
-    - ipywidgets >5.1.0
+    - ipywidgets==7.*
     - notebook >4.1
     - traitlets
   run:
     - python
     - numpy
-    - ipywidgets >5.1.0
+    - ipywidgets==7.*
     - notebook >4.1
     - jupyter
     - traitlets

--- a/devtools/recipe/meta.yaml
+++ b/devtools/recipe/meta.yaml
@@ -9,13 +9,13 @@ requirements:
   build:
     - python
     - setuptools
-    - ipywidgets >=0.5.2
+    - ipywidgets==7.*
     - notebook
 
   run:
     - python
     - numpy
-    - ipywidgets >=0.5.2
+    - ipywidgets==7.*
     - notebook
 
 test:

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - jupyterlab
     - nodejs
     - yarn
-    - ipywidgets
+    - ipywidgets==7.*
 
     # Testing
     - mock

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ setup_args = {
         'pytest'
     ],
     'install_requires': [
-        'ipywidgets>=7',
+        'ipywidgets==7',
         'jupyterlab_widgets',
         'numpy',
     ],

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ setup_args = {
         'pytest'
     ],
     'install_requires': [
-        'ipywidgets==7',
+        'ipywidgets>=7,<8',
         'jupyterlab_widgets',
         'numpy',
     ],


### PR DESCRIPTION
Following the discussion in #1032 and [here](https://github.com/jupyter-incubator/sparkmagic/issues/769), it seems that nglview is only compatible with version 7 of ipywidgets.  So I went ahead and pinned this in the environment.yml and setup.py.  Feel free to close this again if I've misjudged the situation.