### PR TITLE
Set `sharedPackages` to support multiple versions

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -93,7 +93,13 @@
   "styleModule": "style/index.js",
   "jupyterlab": {
     "extension": "lib/jupyterlab-plugin",
-    "outputDir": "nglview-js-widgets/labextension"
+    "outputDir": "nglview-js-widgets/labextension",
+    "sharedPackages": {
+      "@jupyter-widgets/base": {
+        "bundled": false,
+        "singleton": true
+      }
+    }
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Fix #1060.

Migration guide (to v7) mentions `'@jupyter-widgets/base'` should be an external dependency, but the guide only fixes nbextension.
https://ipywidgets.readthedocs.io/en/8.0.5/migration_guides.html#updating-webpack-configuration

The corresponding config for labextension is `jupyterlab.sharedPackages`.
https://jupyterlab.readthedocs.io/en/3.6.x/extension/extension_dev.html#deduplication

I followed https://github.com/jupyter-widgets/widget-cookiecutter/pull/72.