### PR TITLE
Run all archived messages when embedded widget is uninitialized

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
     - python>=3.6
     - pip
     - pytest
-    - jupyterlab
+    - jupyterlab~=3.0
     - nodejs
     - yarn
     - ipywidgets

--- a/js/src/widget_ngl.ts
+++ b/js/src/widget_ngl.ts
@@ -445,11 +445,11 @@ class NGLView extends widgets.DOMWidgetView{
 
 
         // fire any msg with "fire_embed"
-        that.model.get("_ngl_msg_archive").forEach(function(msg){
+        for (const msg of that.model.get("_ngl_msg_archive")) {
             if (msg.fire_embed){
-                that.on_msg(msg);
+                await that.on_msg(msg);
             }
-        })
+        }
 
         // Must call _set_representation_from_repr_dict after "fire_embed"
         // User might add Shape (buffer component) to the view and the buffer component

--- a/js/src/widget_ngl.ts
+++ b/js/src/widget_ngl.ts
@@ -104,7 +104,10 @@ class NGLView extends widgets.DOMWidgetView{
 
     createStage(){
         // init NGL stage
-        var stage_params = this.model.get("_ngl_full_stage_parameters");
+        var stage_params = {
+            // Shallow copy so that _ngl_full_stage_parameters is not updated yet
+            ...this.model.get("_ngl_full_stage_parameters")
+        };
         if (!("backgroundColor" in stage_params)){
             stage_params["backgroundColor"] = "white"
         }
@@ -399,17 +402,20 @@ class NGLView extends widgets.DOMWidgetView{
     async handleEmbed(){
         var that = this;
         var ngl_msg_archive = that.model.get("_ngl_msg_archive");
+        var ngl_stage_params = that.model.get('_ngl_full_stage_parameters');
+        const camera_orientation = that.model.get("_camera_orientation");
 
-        if (!that.model.get("_ngl_is_initialized")) {
+        if (
+            Object.keys(ngl_stage_params).length === 0
+            && camera_orientation.length === 0
+        ) {
             console.log("No state stored; initializing embedded widget for the first time.");
-            for (const msg of that.model.get("_ngl_msg_archive")) {
-                console.log("Running msg " + JSON.stringify(msg));
+            for (const msg of ngl_msg_archive) {
                 await that.on_msg(msg);
             }
             return
         }
 
-        var ngl_stage_params = that.model.get('_ngl_full_stage_parameters');
         var loadfile_list = [];
 
         _.each(ngl_msg_archive, function(msg: any){
@@ -426,7 +432,7 @@ class NGLView extends widgets.DOMWidgetView{
 
         var compList = await Promise.all(loadfile_list)
         that.stage.setParameters(ngl_stage_params);
-        that.set_camera_orientation(that.model.get("_camera_orientation"));
+        that.set_camera_orientation(camera_orientation);
         that.touch();
 
         // Outside notebook

--- a/js/src/widget_ngl.ts
+++ b/js/src/widget_ngl.ts
@@ -143,7 +143,6 @@ class NGLView extends widgets.DOMWidgetView{
                 this.set_camera_orientation(that.model.get("_camera_orientation"));
             }
         }
-        that.model.set("_ngl_is_initialized", true)
     }
 
     isEmbeded(){

--- a/js/src/widget_ngl.ts
+++ b/js/src/widget_ngl.ts
@@ -140,6 +140,7 @@ class NGLView extends widgets.DOMWidgetView{
                 this.set_camera_orientation(that.model.get("_camera_orientation"));
             }
         }
+        that.model.set("_ngl_is_initialized", true)
     }
 
     isEmbeded(){
@@ -398,6 +399,16 @@ class NGLView extends widgets.DOMWidgetView{
     async handleEmbed(){
         var that = this;
         var ngl_msg_archive = that.model.get("_ngl_msg_archive");
+
+        if (!that.model.get("_ngl_is_initialized")) {
+            console.log("No state stored; initializing embedded widget for the first time.");
+            for (const msg of that.model.get("_ngl_msg_archive")) {
+                console.log("Running msg " + JSON.stringify(msg));
+                await that.on_msg(msg);
+            }
+            return
+        }
+
         var ngl_stage_params = that.model.get('_ngl_full_stage_parameters');
         var loadfile_list = [];
 
@@ -1068,7 +1079,7 @@ class NGLView extends widgets.DOMWidgetView{
         return label
 	}
 
-    on_msg(msg) {
+    async on_msg(msg) {
         // TODO: re-organize
         if (('ngl_view_id' in msg) && (msg.ngl_view_id !== this.ngl_view_id)){
             return
@@ -1107,9 +1118,9 @@ class NGLView extends widgets.DOMWidgetView{
                             // are serialized separately, also it unwantedly sets the orientation
                             msg.kwargs.defaultRepresentation = false
                         }
-                        this._handleStageLoadFile(msg);
+                        await this._handleStageLoadFile(msg);
                     } else {
-                            stage_func.apply(stage, new_args);
+                        stage_func.apply(stage, new_args);
                     }
                     break;
                 case 'Viewer':

--- a/nglview/staticlab/package.json
+++ b/nglview/staticlab/package.json
@@ -68,7 +68,7 @@
     "@types/chai": "^4.1.4",
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^2.2.48",
-    "@types/node": "^14.0.0",
+    "@types/node": "^16.0.0",
     "@types/requirejs": "^2.1.31",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
@@ -94,8 +94,14 @@
   "jupyterlab": {
     "extension": "lib/jupyterlab-plugin",
     "outputDir": "nglview-js-widgets/labextension",
+    "sharedPackages": {
+      "@jupyter-widgets/base": {
+        "bundled": false,
+        "singleton": true
+      }
+    },
     "_build": {
-      "load": "static/remoteEntry.08554612fd96651a0411.js",
+      "load": "static/remoteEntry.083de3aa9e5a4fa345f7.js",
       "extension": "./extension",
       "style": "./style"
     }

--- a/nglview/staticlab/package.json
+++ b/nglview/staticlab/package.json
@@ -101,7 +101,7 @@
       }
     },
     "_build": {
-      "load": "static/remoteEntry.083de3aa9e5a4fa345f7.js",
+      "load": "static/remoteEntry.377152ba80b1221406a6.js",
       "extension": "./extension",
       "style": "./style"
     }

--- a/nglview/staticlab/package.json
+++ b/nglview/staticlab/package.json
@@ -101,7 +101,7 @@
       }
     },
     "_build": {
-      "load": "static/remoteEntry.377152ba80b1221406a6.js",
+      "load": "static/remoteEntry.384255e245feac4c28fc.js",
       "extension": "./extension",
       "style": "./style"
     }

--- a/nglview/staticlab/package.json
+++ b/nglview/staticlab/package.json
@@ -101,7 +101,7 @@
       }
     },
     "_build": {
-      "load": "static/remoteEntry.384255e245feac4c28fc.js",
+      "load": "static/remoteEntry.c157c608b5b3770ee85f.js",
       "extension": "./extension",
       "style": "./style"
     }

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -171,7 +171,6 @@ class NGLWidget(DOMWidget):
     _widget_theme = None
     _ngl_serialize = Bool(False).tag(sync=True)
     _ngl_msg_archive = List().tag(sync=True)
-    _ngl_is_initialized = Bool(False).tag(sync=True)
     _ngl_coordinate_resource = Dict().tag(sync=True)
     _representations = List().tag(sync=False)
     _ngl_color_dict = Dict().tag(sync=True)

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -171,6 +171,7 @@ class NGLWidget(DOMWidget):
     _widget_theme = None
     _ngl_serialize = Bool(False).tag(sync=True)
     _ngl_msg_archive = List().tag(sync=True)
+    _ngl_is_initialized = Bool(False).tag(sync=True)
     _ngl_coordinate_resource = Dict().tag(sync=True)
     _representations = List().tag(sync=False)
     _ngl_color_dict = Dict().tag(sync=True)


### PR DESCRIPTION
This PR implements the proposal discussed in #1063.

I made two changes that weren't discussed there:

1. `_ngl_is_initialized` is set in `createStage`, not `handleEmbed`, to ensure it is always set when the JS runs (but also after `handleEmbed`)
2. I had to make `on_msg` async. This is because it is essential that each message completes before the next one is triggered to avoid things like trying to add representations to a missing component. I learnt this the hard way. My understanding is that this won't change behavior - on paths where `on_msg` doesn't `await`, execution will never be suspended and thus the function will run synchronously; on the other hand, when the function does `await` it's the last thing it does, so the only difference is that the `on_msg` function sticks around on the queue instead of the already async inner function. What it does do is allow `on_msg` to be awaited so that messages can be executed and completed in order. This may be of use elsewhere, I'm not sure - I feel like NGLView does sometimes "forget" something I told it.

I also added the `jupyterlab~=3.0` pin to the Conda environment as discussed.

I have a lot of files that have been generated by NPM (or something), including three that are already checked in - so I've added them in a separate commit in case this is a mistake of some sort.

```
	modified:   nglview/static/index.js
	modified:   nglview/static/index.js.map
	modified:   nglview/staticlab/package.json
```

Hope this is useful! I think from what I've learned I can hack something together for my cookbook even if this doesn't get merged, so thanks for your help!

Closes #1063
