### PR TITLE
Update widget.py: fix html icon display none

### DIFF
--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -109,6 +109,7 @@ def write_html(fp, views, frame_range=None):
     _set_serialization(views)
     # FIXME: allow add jquery-ui link?
     snippet = '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.css">\n'
+    snippet += '<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css">\n'
     snippet += embed.embed_snippet(views)
     html_code = embed.html_template.format(title='nglview-demo',
                                            snippet=snippet)


### PR DESCRIPTION
Fix the problem that the icons does not display in html.

```shell
> python -c 'import nglview; print(nglview.__version__)'
3.0.6
> python -c 'import ipywidgets; print(ipywidgets.__version__)'
8.1.0
```