### PR TITLE
Make moving making work again

### DIFF
--- a/nglview/contrib/movie.py
+++ b/nglview/contrib/movie.py
@@ -223,7 +223,7 @@ class MovieMaker:
             frame, movie_making=True, render_params=self.render_params)
         self._progress.description = 'Rendering ...'
 
-        def on_msg(widget, msg, _):
+        def on_msg(widget, msg, buffers):
             if msg['type'] == 'movie_image_data':
                 image_array.append(msg.get('data'))
                 try:

--- a/nglview/tests/test_widget.py
+++ b/nglview/tests/test_widget.py
@@ -238,29 +238,29 @@ def test_API_promise_to_have():
                          [view])['methodName'] == 'setSyncCamera'
 
     msg = dict(type='request_frame', data=dict())
-    view._handle_custom_msg(msg=msg, buffers=[])
+    view._handle_nglview_custom_msg(None, msg=msg, buffers=[])
     msg = dict(type='repr_parameters', data=dict(name='hello'))
-    view._handle_custom_msg(msg=msg, buffers=[])
+    view._handle_nglview_custom_msg(None, msg=msg, buffers=[])
     view.loaded = True
     msg = dict(type='request_loaded', data=True)
-    view._handle_custom_msg(msg=msg, buffers=[])
+    view._handle_nglview_custom_msg(None, msg=msg, buffers=[])
     view.loaded = False
     msg = dict(type='request_loaded', data=True)
-    view._handle_custom_msg(msg=msg, buffers=[])
+    view._handle_nglview_custom_msg(None, msg=msg, buffers=[])
     msg = dict(type='all_reprs_info', data=REPR_DICT)
-    view._handle_custom_msg(msg=msg, buffers=[])
+    view._handle_nglview_custom_msg(None, msg=msg, buffers=[])
     msg = dict(type='stage_parameters', data=dict())
-    view._handle_custom_msg(msg=msg, buffers=[])
+    view._handle_nglview_custom_msg(None, msg=msg, buffers=[])
     # test negative frame (it will be set to self.count - 1)
     view.frame = -1
     msg = dict(type='request_frame', data=dict())
     # async_message
     msg  = {'type': 'async_message', 'data': 'ok'}
-    view._handle_custom_msg(msg, [])
+    view._handle_nglview_custom_msg(None, msg, [])
     # render_image
     r = view.render_image()
     msg = {'type': 'image_data', 'ID': r.model_id, 'data': b'YmxhIGJsYQ=='}
-    view._handle_custom_msg(msg, [])
+    view._handle_nglview_custom_msg(None, msg, [])
     view.loaded = True
     view.show_only([
         0,

--- a/nglview/widget.py
+++ b/nglview/widget.py
@@ -206,7 +206,7 @@ class NGLWidget(DOMWidget):
         self.stage = Stage(view=self)
         self.control = ViewerControl(view=self)
         self._handle_msg_thread = threading.Thread(
-            target=self.on_msg, args=(self._handle_custom_msg, ))
+            target=self.on_msg, args=(self._handle_nglview_custom_msg, ))
         # # register to get data from JS side
         self._handle_msg_thread.daemon = True
         self._handle_msg_thread.start()
@@ -1036,13 +1036,16 @@ class NGLWidget(DOMWidget):
                           ],
                           kwargs=params)
 
-    def _handle_custom_msg(self, msg, buffers):
+    def _handle_nglview_custom_msg(self, _, msg, buffers):
+        # Similar signature to
+        # https://github.com/jupyter-widgets/ipywidgets/blob/b78de43e12ff26e4aa16e6e4c6844a7c82a8ee1c/python/ipywidgets/ipywidgets/widgets/widget_string.py#L122
+        # NOTE: "self" is not counted as first argument.
         """store message sent from Javascript.
 
         How? use view.on_msg(get_msg)
 
         Notes: message format should be {'type': type, 'data': data}
-        _handle_custom_msg will call appropriate function to handle message "type"
+        _handle_nglview_custom_msg will call appropriate function to handle message "type"
         """
         self._ngl_msg = msg
 


### PR DESCRIPTION
#1102 

Long story short:
I accidentally used `_handle_custom_msg` method name that overwrites  https://github.com/jupyter-widgets/ipywidgets/blob/b78de43e12ff26e4aa16e6e4c6844a7c82a8ee1c/python/ipywidgets/ipywidgets/widgets/widget.py#L788

The `view. on_msg(self. _handle_custom_msg)` has never worked due to the wrong signature. This failure blocks `on_msg` function execution in https://github.com/nglviewer/nglview/blob/98d7df9c5b2c035278724eacfb8184631c17015b/nglview/contrib/movie.py#L226

The `view._handle_custom_msg`, however, is still be executed in different code branch: https://github.com/jupyter-widgets/ipywidgets/blob/b78de43e12ff26e4aa16e6e4c6844a7c82a8ee1c/python/ipywidgets/ipywidgets/widgets/widget.py#L761-L782