### PR TITLE
Remove upper boundary from jupyter_packaging version

### DIFF
--- a/js/pyproject.toml
+++ b/js/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging>=0.7.9", "jupyterlab~=3.0", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "setuptools>=40.8.0", "wheel", "versioneer-518"]
+requires = ["jupyter_packaging>=0.7.9", "setuptools>=40.8.0", "wheel", "versioneer-518"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hey,
currently nglview is not installable under Python 3.13.
The reason is a deprecation concerning the jupyter_packaging build packaging dependency: https://github.com/jupyter/jupyter-packaging/pull/153
Simply unbounding the dependency allows the installation under 3.13 (installation tested in a Docker container, but maybe one should check if everything still works correctly).
For 3.13 we need a version of at least 0.12.2, but I opted to not set `jupyter_packaging>=0.12.2` since 0.12.2 does only support Python 3.7+, while nglview supports Python 3.6+.
It would be cool if we could get a new version on PyPI to make the package installable again :)
Best,
Wanja