### PR TITLE
Fix pkg_resources deprecation warning

### DIFF
--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+import sys
 
 from . import adaptor, datafiles, show, widget
 from .adaptor import *
@@ -9,14 +10,21 @@ from .show import *
 from .utils import js_utils, widget_utils
 from .widget import NGLWidget, write_html
 
-import pkg_resources
-
-try:
-    __version__ = pkg_resources.get_distribution("nglview").version
-except pkg_resources.DistributionNotFound:
-    __version__ = "unknown"
-
-del pkg_resources
+if sys.version_info >= (3, 8):
+    import importlib.metadata
+    try:
+        __version__ = importlib.metadata.version("nglview")
+    except importlib.metadata.PackageNotFoundError:
+        __version__ = "unknown"
+    del importlib.metadata
+else:
+    # pkg_resources is deprecated, only use it if importlib.metadata is not available (Python < 3.8)
+    import pkg_resources
+    try:
+        __version__ = pkg_resources.get_distribution("nglview").version
+    except pkg_resources.DistributionNotFound:
+        __version__ = "unknown"
+    del pkg_resources
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")


### PR DESCRIPTION
* Warning:
`nglview/__init__.py:12: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html`