### PR TITLE
Fix install in an empty Python 3.13 virtualenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_args = {
          "nglview.labextension": ["*"],
      },
     'data_files': data_files,
-    'setup_requires': ['jupyter_packaging>=0.12.2']
+    'setup_requires': ['jupyter_packaging>=0.12.2'],
     'install_requires': [
         'ipywidgets>=8',
         'notebook>=7',


### PR DESCRIPTION
Follows recommendations at https://pypi.org/project/jupyter-packaging/