### PR TITLE
chore: use jupyter_packaging>=0.12.2 for Python 3.13+ and fix broken CI

### DIFF
--- a/.github/nglview-gha.yml
+++ b/.github/nglview-gha.yml
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib
   - moviepy
   - imageio
-  - pillow
+  - pillow<11.2.1
   - numpy
   - rdkit
   - mdanalysis

--- a/.github/nglview-gha.yml
+++ b/.github/nglview-gha.yml
@@ -24,6 +24,7 @@ dependencies:
   - imageio
   - pillow<11.2.1
   - numpy
+  - numpy<2.3.0
   - rdkit
   - mdanalysis
   - mdtraj

--- a/devtools/circleci/install_miniconda.sh
+++ b/devtools/circleci/install_miniconda.sh
@@ -10,9 +10,9 @@ yum install -y \
 # export PATH=/root/miniconda3/bin:$PATH
 export PATH=/opt/conda/bin/:$PATH
 conda update --yes --all
-conda install --yes conda-build anaconda-client numpy matplotlib
+conda install --yes conda-build anaconda-client numpy<2.3 matplotlib
 conda info
-conda install --yes jupyter notebook nose numpy mock coverage cython netcdf4
+conda install --yes jupyter notebook nose numpy<2.3 mock coverage cython netcdf4
 # pytraj
 pip install pytraj
 # mdanalysis

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,7 +12,7 @@ requirements:
     - traitlets
   run:
     - python
-    - numpy
+    - numpy<2.3
     - ipywidgets
     - notebook >4.1
     - jupyter

--- a/devtools/outdated/nglview-jupyterlab.sh
+++ b/devtools/outdated/nglview-jupyterlab.sh
@@ -12,7 +12,7 @@ ipywidgets_version=7.1.2
 echo "nglview root folder: $nglview_src"
 echo "Creating env $env"
 
-conda create -n $env python=${python_version} numpy nomkl -y
+conda create -n $env python=${python_version} numpy<2.3 nomkl -y
 source activate $env
 conda install setuptools -c conda-forge --force -y
 conda install notebook==${notebook_version} -c conda-forge -y

--- a/environment.yml
+++ b/environment.yml
@@ -34,4 +34,4 @@ dependencies:
     - matplotlib
     - moviepy
     - imageio
-    - pillow
+    - pillow<11.2.1

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
     - coveralls
 
     # Scientific
-    - numpy
+    - numpy<2.3
     - pandas
     - ase
     - parmed

--- a/nglview/__init__.py
+++ b/nglview/__init__.py
@@ -11,14 +11,14 @@ from .utils import js_utils, widget_utils
 from .widget import NGLWidget, write_html
 
 if sys.version_info >= (3, 8):
-    import importlib.metadata
+    import importlib.metadata as importlib_metadata
     try:
-        __version__ = importlib.metadata.version("nglview")
-    except importlib.metadata.PackageNotFoundError:
+        __version__ = importlib_metadata.version("nglview")
+    except importlib_metadata.PackageNotFoundError:
         __version__ = "unknown"
-    del importlib.metadata
+    del importlib_metadata
 else:
-    # pkg_resources is deprecated, only use it if importlib.metadata is not available (Python < 3.8)
+    # pkg_resources is deprecated, only use it if importlib_metadata is not available (Python < 3.8)
     import pkg_resources
     try:
         __version__ = pkg_resources.get_distribution("nglview").version

--- a/pip-requirements-test.txt
+++ b/pip-requirements-test.txt
@@ -19,4 +19,4 @@ simpletraj
 matplotlib
 moviepy==0.2.2.11
 imageio
-pillow
+pillow<11.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-  "jupyter_packaging>=0.7.9; python_version<3.13",
-  "jupyter_packaging>=0.12.2; python_version>=3.13",
+  "jupyter_packaging>=0.7.9; python_version<'3.13'",
+  "jupyter_packaging>=0.12.2; python_version>='3.13'",
   "setuptools>=75.6.0",
   "wheel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["jupyter_packaging>=0.7.9", "setuptools>=75.6.0", "wheel"]
+requires = [
+  "jupyter_packaging>=0.7.9; python_version<3.13",
+  "jupyter_packaging>=0.12.2; python_version>=3.13",
+  "setuptools>=75.6.0",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup_args = {
         'notebook>=7',
         'jupyterlab>=3',
         'jupyterlab_widgets',
-        'numpy',
+        'numpy<2.3',
     ],
     'extras_require': {
         "simpletraj": ["simpletraj"],


### PR DESCRIPTION
If `__init__.py` discards `importlib.metadata`, it would have an unexpected side-effect. For example, I put the link that NumPy testing library also uses `importlib.metadata` to fail.

🔗. https://github.com/nglviewer/nglview/pull/1162#issuecomment-3305110509