### PR TITLE
chore: jupyter_packaging>=0.12.2 only for python3.13 or later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["jupyter_packaging>=0.7.9", "setuptools>=75.6.0", "wheel"]
+requires = [
+  "jupyter_packaging>=0.7.9; python_version<3.13",
+  "jupyter_packaging>=0.12.2; python_version>=3.13",
+  "setuptools>=75.6.0",
+  "wheel",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Follow-up for https://github.com/nglviewer/nglview/pull/1123.

Forces Python to use `jupyter_packaging>=0.12.2` for Python 3.13 or later since `jupyter_packaging>=0.7.9,<0.12.2` is not compatible with.

* `build-system.requires` follows [PEP 508](https://peps.python.org/pep-0518/#build-system-table)
* PEP 508 has [environment makers](https://peps.python.org/pep-0508/#environment-markers) to switch dependencies based on a Python version.