### PR TITLE
chore: avoid pillow 11.2.1 or newer to avoid TypeError

### DIFF
--- a/.github/nglview-gha.yml
+++ b/.github/nglview-gha.yml
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib
   - moviepy
   - imageio
-  - pillow
+  - pillow<11.2.1
   - numpy
   - rdkit
   - mdanalysis

--- a/environment.yml
+++ b/environment.yml
@@ -34,4 +34,4 @@ dependencies:
     - matplotlib
     - moviepy
     - imageio
-    - pillow
+    - pillow<11.2.1

--- a/pip-requirements-test.txt
+++ b/pip-requirements-test.txt
@@ -19,4 +19,4 @@ simpletraj
 matplotlib
 moviepy==0.2.2.11
 imageio
-pillow
+pillow<11.2.1


### PR DESCRIPTION
Just to make CI pass. It would be needed to fix the root problem later.

🔗. https://github.com/nglviewer/nglview/pull/1162#issuecomment-3306366398